### PR TITLE
rubocop指摘無効化の方法を修正

### DIFF
--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -15,6 +15,6 @@ module SessionsHelper
 
   def logout
     session.delete(:user_id)
-    current_user = nil
+    current_user = nil # rubocop:disable Lint/UselessAssignment
   end
 end

--- a/config/rubocop/rubocop.yml
+++ b/config/rubocop/rubocop.yml
@@ -759,5 +759,3 @@ RSpec/Rails/MinitestAssertions: # new in 2.17
   Enabled: true
 RSpec/Rails/TravelAround: # new in 2.19
   Enabled: true
-Lint/UselessAssignment:
-  Enabled: false


### PR DESCRIPTION
## このプルリクエストで何をしたのか
SessionHelperのLint/UselessAssignmentを無効化する際にrubocop.ymlでdisableにしているが、これは不適切。
該当箇所にdisableコメントを追記した。

## チェックリスト
- [x] 動作確認は実行した?
- [x] rubocopは実行した？

## その他参考情報
- 実装する上で参考にしたサイトなどがあればリンクをここに貼ること
